### PR TITLE
[Fix] Update confounds.py

### DIFF
--- a/xcp_abcd/utils/confounds.py
+++ b/xcp_abcd/utils/confounds.py
@@ -64,7 +64,7 @@ def load_acompcor(confoundspd, confoundjs):
 
     WM = []; CSF = []
     for key, value in confoundjs.items():
-        if 'a_comp_cor' in key:
+        if 'comp_cor' in key and 't' not in key:
             if value['Mask']=='WM' and value['Retained']==True:
                 WM.append([key,value['VarianceExplained']])
             if value['Mask']=='CSF' and value['Retained']==True:


### PR DESCRIPTION
Changes acompcor loading strategy to be compatible with fMRIPrep 21.0.0+ (#267)

## Changes proposed in this pull request
This update makes acompcor component loading compatible with previous and newer versions of fMRIPrep

## Documentation that should be reviewed
No documentation should be changed.

